### PR TITLE
Fix for UIScrollView's locking up and stuttering on scroll when used …

### DIFF
--- a/CWStackController/CWStackPanGestureRecognizer.m
+++ b/CWStackController/CWStackPanGestureRecognizer.m
@@ -28,6 +28,21 @@
 {
     [super touchesMoved:touches withEvent:event];
     
+    // 6S 3D Touch fix, if we're moving in/out of the screen discard this event
+    for (UITouch *touch in touches) {
+        if ([touch respondsToSelector:@selector(force)]) {
+            CGPoint location = [touch locationInView:self.view];
+            CGPoint prevLocation = [touch previousLocationInView:self.view];
+            if (CGPointEqualToPoint(location, prevLocation)) {
+                // Point has not moved - must be 3D Touch which is not handled by this recognizer
+                return;
+            }
+        }
+        else {
+            break;
+        }
+    }
+    
     if (self.state == UIGestureRecognizerStateFailed) {
         return;
     }


### PR DESCRIPTION
…on an iPhone 6S with 3D Touch (as a 3D Touch will generate "touchesMoved" events).

The fix is simply checking all of the touches to see whether the touch starts and ends in the same place, if it does then that event is discarded.
